### PR TITLE
chore: add link to input accept mdn docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ JavaScript implementation of the "accept" attribute for HTML5 `<input type="file
 [![npm version](https://badge.fury.io/js/attr-accept.svg)](https://badge.fury.io/js/attr-accept)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#Attributes for more information.
+See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept for more information.
 
 Installation
 =====


### PR DESCRIPTION
what do you think about direct link to input#accept, not link to all of attributes?