### PR TITLE
Add a module entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "JavaScript implementation of the \"accept\" attribute for HTML5 <input type=\"file\">",
   "version": "0.0.0-development",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "types": "index.d.ts",
   "scripts": {
     "build": "webpack -p",


### PR DESCRIPTION
This PR adds a `module` entry to `package.json`, pointing to `src/index.js`, which allows tools that use ES modules to avoid having to interoperate with the package's CommonJS build. This works around a problem that I've been experiencing including `react-dropzone` in a project that builds using Rollup.

## More Details of My Problem

I'm including `react-dropzone` in a project that build using Rollup and have run into an issue with it importing this package (`attr-accept`).

`react-dropzone` ships an ES module build, but this package does not, which causes `@rollup/plugin-commonjs` to run into some interop issues, and means that [this line](https://github.com/react-dropzone/react-dropzone/blob/199c9ea20b501cc3997cbdcc63ea6fb972e20360/src/utils/index.js#L41) ends up trying to call an object, which throws an exception. (It's basically calling `accepts()` when it needs to be calling `accepts.default()`.)

Interop issues with `@rollup/plugin-commonjs` are discussed in great detail here: https://github.com/rollup/plugins/issues/481

I've worked around the issue in my project through a horrible hack in my Rollup configuration to add a `module` entry to this package's `package.json`. I would love to get a version of this package published that includes it already so I can get rid of my horrible hack. There are other benefits to exposing an ES module build anyway.