### PR TITLE
fix(types): make `acceptedFiles` optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export default function accept(file: { name?: string, type?: string }, acceptedFiles: string | string[]): boolean;
+export default function accept(file: { name?: string, type?: string }, acceptedFiles?: string | string[]): boolean;


### PR DESCRIPTION
From [implementation](https://github.com/react-dropzone/attr-accept/blob/66260177829f99c48594dd1fdedaefbb91bdce39/src/index.js#L13) we can see that `acceptedFiles` can be optional.  
This change would allow to pass undefined to second param

```ts
import attrAccept from 'attr-accept'

export function validate(file: File, accept: string | undefined) {
  return attrAccept(file, accept)
}
```