### PR TITLE
Fix TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export default function accept(file: { name?: string, type?: string }, acceptedFiles: string | string[]): boolean;
+declare function accept(file: { name?: string, type?: string }, acceptedFiles: string | string[]): boolean;
+
+export = accept;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
The main entrypoint of this package exports a function using `module.exports = …`. The correct type for this is `export = …`.

**Does this PR introduce a breaking change?**
No

**Other information**

Fixes #29