### PR TITLE
fix: replace `.npmignore` with `files` field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.idea
-.npmignore
-.babelrc

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "index.d.ts",
+  "files": [
+    "dist",
+    "index.d.ts"
+  ],
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "npm run clean && npm run build:cjs && npm run build:es",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
I've removed the `.npmignore` file as the `files` field in the package is enough for NPM to determine which files should be included. To see this in action run `npm pack --dry-run` in the root directory. This fixes a bug where a bunch of unrelated files ended up in the package:

**Before**
```
.codeclimate.yml
.editorconfig
.eslintrc
.github/workflows/release.yml
.github/workflows/test.yml
LICENSE
README.md
dist/es/index.js
dist/index.js
index.d.ts
package.json
src/index.js
test/index.js
webpack.config.js
```

**After**
```
LICENSE
README.md
dist/es/index.js
dist/index.js
index.d.ts
package.json
```

**Does this PR introduce a breaking change?**
No.

**Other information**
None.