### PR TITLE
chore: run tests on Node.js 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [18, 20, 22]
 
     steps:
       - name: Checkout repository
@@ -29,20 +29,13 @@ jobs:
         run: npm ci
 
       - name: Run tests
+        if: matrix.node-version != 22
         run: npm test
 
-      - name: Collect coverage
-        uses: coverallsapp/github-action@v2
-        with:
-          flag-name: run-${{ join(matrix.*, '-') }}
-          parallel: true
+      - name: Run tests with coverage
+        if: matrix.node-version == 22
+        run: npm run test:coverage
 
-  coverage:
-    name: Publish coverage
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish coverage
+      - name: Collect coverage
+        if: matrix.node-version == 22
         uses: coverallsapp/github-action@v2
-        with:
-          parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -46,5 +46,3 @@ accept({
 ## Contributing
 
 Checkout the organization [CONTRIBUTING.md](https://github.com/react-dropzone/.github/blob/main/CONTRIBUTING.md).
-
-**NOTE** The minimum required Node version for development is v20.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "prepublish": "npm test",
     "pretest": "npm run lint",
-    "test": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info",
+    "test": "node --test",
+    "test:coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info",
     "test:watch": "node --test --watch",
     "lint": "eslint src/ test/",
     "lint:fix": "eslint --fix src/ test/",


### PR DESCRIPTION
Collecting coverage should only be required for one of the runs since the coverage will not change between versions of Node.js.